### PR TITLE
Fix data count mismatch between different writer open.

### DIFF
--- a/yottadisk.go
+++ b/yottadisk.go
@@ -313,6 +313,7 @@ func buildYottaDisk(header *ydcommon.Header, storage storage.Storage, opt *opt.O
 	for i := uint32(0); i < header.RangeCaps; i++ {
 		index.sizes[i] = (uint16(indexSizeBuf[(i << 1) + 1]) << 8) | uint16(indexSizeBuf[i << 1])
 	}
+	index.total = header.DataCount
 
 	yd := &YottaDisk{
 		opt,


### PR DESCRIPTION
Fix issue that open yottadisk twice saw different data count.

TODO: add test case.