### PR TITLE
[Don't Merge]Fix hybrid test goroutine stack overflow

### DIFF
--- a/yottadisk.go
+++ b/yottadisk.go
@@ -313,6 +313,7 @@ func buildYottaDisk(header *ydcommon.Header, storage storage.Storage, opt *opt.O
 	for i := uint32(0); i < header.RangeCaps; i++ {
 		index.sizes[i] = (uint16(indexSizeBuf[(i << 1) + 1]) << 8) | uint16(indexSizeBuf[i << 1])
 	}
+	index.total = header.DataCount
 
 	yd := &YottaDisk{
 		opt,


### PR DESCRIPTION
hybrid test failed for goroutine stack overflow if running with 5T & above disk space.
Now use 2000(adjustable) as a parallel limitation to avoid stack overflow.