### PR TITLE
Add data reconstruct engine and sample engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ A data block save/load lib based on key-value styled db APIs.
 ### Prerequisites
 YottaDisk is developped by Golang, so install golang developping environment first.
 Also, YottaDisk has 2 external dependencies. a simple golang-lru and ethereum.
-Install these 2 before using YottaDisk
+Install these 3 before using YottaDisk
 ```
 go get github.com/hashicorp/golang-lru
 go get github.com/ethereum/go-ethereum
+go get github.com/klauspost/reedsolomon
 ```
 
 ### Installing

--- a/context.go
+++ b/context.go
@@ -196,7 +196,7 @@ func (c *Context) putAt(value []byte, sp *storagePointer) (uint32, error) {
 	}
 
 	if debugPrint {
-		fmt.Printf("put data %v @ %v\n", value[:32], sp)
+		fmt.Printf("put data %x @ %v\n", value[:32], sp)
 	}
 
 	dataPos := sp.posIdx

--- a/opt/property.go
+++ b/opt/property.go
@@ -2,7 +2,7 @@ package opt
 
 // properties for internal use.
 var (
-	DebugPrint             = true // Debug print
+	DebugPrint             = false // Debug print
 	IgnoreStorageHeaderErr = true  // Ignore storage header mismatch with config.
 	expendRatioM           = 1.2   // Expending ratio of M (col of index table)
 )

--- a/opt/property.go
+++ b/opt/property.go
@@ -2,7 +2,7 @@ package opt
 
 // properties for internal use.
 var (
-	DebugPrint             = false // Debug print
+	DebugPrint             = true // Debug print
 	IgnoreStorageHeaderErr = true  // Ignore storage header mismatch with config.
 	expendRatioM           = 1.2   // Expending ratio of M (col of index table)
 )

--- a/recovery/recovery.go
+++ b/recovery/recovery.go
@@ -20,13 +20,13 @@ type DataRecoverEngine struct {
 	config      *DataRecoverOptions
 	ytfs        *ytfs.YTFS
 
-	p2p P2PNetwork
+	p2p         P2PNetwork
 
-	taskList   []*TaskDescription
-	taskCh     chan *TaskDescription
-	taskStatus map[uint64]TaskResponse
+	taskList    []*TaskDescription
+	taskCh      chan *TaskDescription
+	taskStatus  map[uint64]TaskResponse
 
-	lock sync.Mutex
+	lock        sync.Mutex
 }
 
 // TaskDescription describes the recovery task.
@@ -73,8 +73,8 @@ type TaskResponse struct {
 	Desc   string
 }
 
-// NewDataRecoverEngine creates recovery data engine
-func NewDataRecoverEngine(ytfs *ytfs.YTFS, p2p P2PNetwork, opt *DataRecoverOptions) (*DataRecoverEngine, error) {
+// NewEngine creates recovery data engine
+func NewEngine(ytfs *ytfs.YTFS, p2p P2PNetwork, opt *DataRecoverOptions) (*DataRecoverEngine, error) {
 	enc, error := reedsolomon.New(int(opt.DataShards), int(opt.ParityShards))
 	if error != nil {
 		return nil, error
@@ -121,7 +121,7 @@ func (recoverEngine *DataRecoverEngine) startRecieveTask() {
 }
 
 // RecoverData recieves a recovery task and start working later on
-func (recoverEngine *DataRecoverEngine) RecoverData(td *TaskDescription, successCB ...func() TaskResponse) TaskResponse {
+func (recoverEngine *DataRecoverEngine) RecoverData(td *TaskDescription) TaskResponse {
 	err := recoverEngine.validateTask(td)
 	if err != nil {
 		recoverEngine.recordError(td, err)

--- a/recovery/recovery.go
+++ b/recovery/recovery.go
@@ -135,7 +135,7 @@ func (codec *DataRecoverEngine) validateTask(td *TaskDescription) error {
 func (codec *DataRecoverEngine) doRecoverData(td *TaskDescription, done chan interface{}) {
 	if ytfsOpt.DebugPrint {
 		for i:=0;i<len(td.RecoverIDs);i++{
-			fmt.Printf("Recovery: start working on td(%d), recover hash = %v\n", td.ID, td.Hashes[td.RecoverIDs[i]])
+			fmt.Printf("Recovery: start working on td(%d), recover hash = %x\n", td.ID, td.Hashes[td.RecoverIDs[i]])
 		}
 	}
 

--- a/recovery/recovery.go
+++ b/recovery/recovery.go
@@ -3,6 +3,7 @@ package recovery
 
 import (
 	"fmt"
+	"runtime"
 	"sync"
 	"time"
 
@@ -13,10 +14,10 @@ import (
 	ytfsOpt "github.com/yottachain/YTFS/opt"
 )
 
-// DataRecoverEngine the rs codec to recovery data
+// DataRecoverEngine the rs recoverEngine to recovery data
 type DataRecoverEngine struct {
 	recoveryEnc reedsolomon.Encoder
-	config      *DataCodecOptions
+	config      *DataRecoverOptions
 	ytfs        *ytfs.YTFS
 
 	p2p P2PNetwork
@@ -72,19 +73,19 @@ type TaskResponse struct {
 	Desc   string
 }
 
-// NewDataCodec creates recovery data codec
-func NewDataCodec(ytfs *ytfs.YTFS, p2p P2PNetwork, opt *DataCodecOptions) (*DataRecoverEngine, error) {
-	enc, error := reedsolomon.New(opt.DataShards, opt.ParityShards)
+// NewDataRecoverEngine creates recovery data engine
+func NewDataRecoverEngine(ytfs *ytfs.YTFS, p2p P2PNetwork, opt *DataRecoverOptions) (*DataRecoverEngine, error) {
+	enc, error := reedsolomon.New(int(opt.DataShards), int(opt.ParityShards))
 	if error != nil {
 		return nil, error
 	}
 
 	maxTasks := opt.MaxTaskInParallel
-	if maxTasks <= 0 || maxTasks > 8 {
-		maxTasks = 8
+	if maxTasks > uint32(runtime.NumCPU()) {
+		maxTasks = uint32(runtime.NumCPU())
 	}
 
-	codec := &DataRecoverEngine{
+	recoverEngine := &DataRecoverEngine{
 		enc,
 		opt,
 		ytfs,
@@ -95,51 +96,51 @@ func NewDataCodec(ytfs *ytfs.YTFS, p2p P2PNetwork, opt *DataCodecOptions) (*Data
 		sync.Mutex{},
 	}
 
-	go codec.startRecieveTask()
-	return codec, nil
+	go recoverEngine.startRecieveTask()
+	return recoverEngine, nil
 }
 
-func (codec *DataRecoverEngine) startRecieveTask() {
-	running := 0
+func (recoverEngine *DataRecoverEngine) startRecieveTask() {
+	running := uint32(0)
 	done := make(chan interface{})
 	for {
 		select {
-		case td := <-codec.taskCh:
-			codec.taskList = append(codec.taskList, td)
+		case td := <-recoverEngine.taskCh:
+			recoverEngine.taskList = append(recoverEngine.taskList, td)
 		case <-done:
 			running--
 		}
 
-		for len(codec.taskList) != 0 && running < codec.config.MaxTaskInParallel {
+		for len(recoverEngine.taskList) != 0 && running < recoverEngine.config.MaxTaskInParallel {
 			running++
-			task := codec.taskList[0]
-			codec.taskList = codec.taskList[1:]
-			go codec.doRecoverData(task, done)
+			task := recoverEngine.taskList[0]
+			recoverEngine.taskList = recoverEngine.taskList[1:]
+			go recoverEngine.doRecoverData(task, done)
 		}
 	}
 }
 
 // RecoverData recieves a recovery task and start working later on
-func (codec *DataRecoverEngine) RecoverData(td *TaskDescription, successCB... func() TaskResponse) TaskResponse {
-	err := codec.validateTask(td)
+func (recoverEngine *DataRecoverEngine) RecoverData(td *TaskDescription, successCB ...func() TaskResponse) TaskResponse {
+	err := recoverEngine.validateTask(td)
 	if err != nil {
-		codec.recordError(td, err)
-		return codec.RecoverStatus(td)
+		recoverEngine.recordError(td, err)
+		return recoverEngine.RecoverStatus(td)
 	}
 
 	// sequenced op on chan
-	codec.taskCh <- td
-	codec.recordTaskResponse(td, TaskResponse{PendingTask, "Task is pending"})
-	return codec.RecoverStatus(td)
+	recoverEngine.taskCh <- td
+	recoverEngine.recordTaskResponse(td, TaskResponse{PendingTask, "Task is pending"})
+	return recoverEngine.RecoverStatus(td)
 }
 
-func (codec *DataRecoverEngine) validateTask(td *TaskDescription) error {
+func (recoverEngine *DataRecoverEngine) validateTask(td *TaskDescription) error {
 	// verify hash
-	if len(td.RecoverIDs) > codec.config.ParityShards {
+	if len(td.RecoverIDs) > int(recoverEngine.config.ParityShards) {
 		return fmt.Errorf("Recovered data should be < ParityShards")
 	}
 
-	if len(td.Hashes) != codec.config.DataShards+codec.config.ParityShards {
+	if len(td.Hashes) != int(recoverEngine.config.DataShards+recoverEngine.config.ParityShards) {
 		return fmt.Errorf("Input hashes length != DataShards+ParityShards")
 	}
 
@@ -147,44 +148,44 @@ func (codec *DataRecoverEngine) validateTask(td *TaskDescription) error {
 	return nil
 }
 
-func (codec *DataRecoverEngine) doRecoverData(td *TaskDescription, done chan interface{}) {
+func (recoverEngine *DataRecoverEngine) doRecoverData(td *TaskDescription, done chan interface{}) {
 	if ytfsOpt.DebugPrint {
 		for i := 0; i < len(td.RecoverIDs); i++ {
 			fmt.Printf("Recovery: start working on td(%d), recover hash = %x\n", td.ID, td.Hashes[td.RecoverIDs[i]])
 		}
 	}
 
-	shards, err := codec.prepareDataShards(td)
+	shards, err := recoverEngine.prepareDataShards(td)
 	if err != nil {
-		codec.recordError(td, err)
+		recoverEngine.recordError(td, err)
 		return
 	}
 
-	codec.recordTaskResponse(td, TaskResponse{ProcessingTask, "EC recovering"})
+	recoverEngine.recordTaskResponse(td, TaskResponse{ProcessingTask, "EC recovering"})
 	// Reconstruct the shards
-	err = codec.recoveryEnc.Reconstruct(shards)
+	err = recoverEngine.recoveryEnc.Reconstruct(shards)
 	if err != nil {
-		codec.recordError(td, err)
+		recoverEngine.recordError(td, err)
 		return
 	}
 
-	if codec.ytfs != nil {
+	if recoverEngine.ytfs != nil {
 		for i := uint32(0); i < uint32(len(td.RecoverIDs)); i++ {
-			err = codec.ytfs.Put(ytfsCommon.IndexTableKey(td.Hashes[td.RecoverIDs[i]]), shards[td.RecoverIDs[i]])
+			err = recoverEngine.ytfs.Put(ytfsCommon.IndexTableKey(td.Hashes[td.RecoverIDs[i]]), shards[td.RecoverIDs[i]])
 			if err != nil {
-				codec.recordError(td, err)
+				recoverEngine.recordError(td, err)
 				return
 			}
 		}
 	}
 
-	codec.recordTaskResponse(td, TaskResponse{SuccessTask, "Task Success"})
+	recoverEngine.recordTaskResponse(td, TaskResponse{SuccessTask, "Task Success"})
 	done <- struct{}{}
 }
 
-func (codec *DataRecoverEngine) prepareDataShards(td *TaskDescription) ([][]byte, error) {
+func (recoverEngine *DataRecoverEngine) prepareDataShards(td *TaskDescription) ([][]byte, error) {
 	recoverIndexSet := map[uint32]interface{}{}
-	shards := make([][]byte, codec.config.DataShards+codec.config.ParityShards)
+	shards := make([][]byte, recoverEngine.config.DataShards+recoverEngine.config.ParityShards)
 	for i := uint32(0); i < uint32(len(td.RecoverIDs)); i++ {
 		shards[td.RecoverIDs[i]] = nil
 		recoverIndexSet[td.RecoverIDs[i]] = struct{}{}
@@ -194,15 +195,15 @@ func (codec *DataRecoverEngine) prepareDataShards(td *TaskDescription) ([][]byte
 		shardSliceID uint32
 		data         []byte
 	}
-	resCh := make(chan *P2PDataReceiveResult, codec.config.DataShards)
+	resCh := make(chan *P2PDataReceiveResult, recoverEngine.config.DataShards)
 	errCh := make(chan error, 1)
 	//Stop those incompleted goroutine by using stopCh
 	stopSigCh := make(chan interface{})
 	for i := 0; i < len(td.Hashes); i++ {
 		if _, ok := recoverIndexSet[uint32(i)]; !ok {
 			go func(shardID uint32) {
-				hash, loc, timeout := td.Hashes[shardID], td.Locations[shardID], codec.config.TimeoutInMS
-				data, err := codec.getShardFromNetwork(hash, loc, timeout, stopSigCh)
+				hash, loc, timeout := td.Hashes[shardID], td.Locations[shardID], recoverEngine.config.TimeoutInMS
+				data, err := recoverEngine.getShardFromNetwork(hash, loc, timeout, stopSigCh)
 				if err == nil {
 					resCh <- &P2PDataReceiveResult{shardID, data}
 				} else {
@@ -211,21 +212,21 @@ func (codec *DataRecoverEngine) prepareDataShards(td *TaskDescription) ([][]byte
 			}(uint32(i))
 		}
 	}
-	codec.recordTaskResponse(td, TaskResponse{ProcessingTask, "Retrieving data from P2P network"})
+	recoverEngine.recordTaskResponse(td, TaskResponse{ProcessingTask, "Retrieving data from P2P network"})
 
-	dataReceived := 0
+	dataReceived := uint32(0)
 	for {
 		select {
 		case res := <-resCh:
 			dataReceived++
 			shards[res.shardSliceID] = res.data
 		case err := <-errCh:
-			codec.recordError(td, fmt.Errorf("ERROR: Retrieve data failed, error %v", err))
+			recoverEngine.recordError(td, fmt.Errorf("ERROR: Retrieve data failed, error %v", err))
 			close(stopSigCh)
 			return nil, err
 		}
 
-		if dataReceived == codec.config.DataShards {
+		if dataReceived == recoverEngine.config.DataShards {
 			close(stopSigCh)
 			break
 		}
@@ -235,29 +236,29 @@ func (codec *DataRecoverEngine) prepareDataShards(td *TaskDescription) ([][]byte
 }
 
 // RecoverStatus queries the status of a task
-func (codec *DataRecoverEngine) RecoverStatus(td *TaskDescription) TaskResponse {
-	codec.lock.Lock()
-	defer codec.lock.Unlock()
-	return codec.taskStatus[td.ID]
+func (recoverEngine *DataRecoverEngine) RecoverStatus(td *TaskDescription) TaskResponse {
+	recoverEngine.lock.Lock()
+	defer recoverEngine.lock.Unlock()
+	return recoverEngine.taskStatus[td.ID]
 }
 
-func (codec *DataRecoverEngine) recordError(td *TaskDescription, err error) {
-	codec.recordTaskResponse(td, TaskResponse{ErrorTask, err.Error()})
+func (recoverEngine *DataRecoverEngine) recordError(td *TaskDescription, err error) {
+	recoverEngine.recordTaskResponse(td, TaskResponse{ErrorTask, err.Error()})
 }
 
-func (codec *DataRecoverEngine) recordTaskResponse(td *TaskDescription, res TaskResponse) {
+func (recoverEngine *DataRecoverEngine) recordTaskResponse(td *TaskDescription, res TaskResponse) {
 	//TODO: link to levelDB
-	codec.lock.Lock()
-	defer codec.lock.Unlock()
-	codec.taskStatus[td.ID] = res
+	recoverEngine.lock.Lock()
+	defer recoverEngine.lock.Unlock()
+	recoverEngine.taskStatus[td.ID] = res
 }
 
-func (codec *DataRecoverEngine) getShardFromNetwork(hash common.Hash, loc P2PLocation, timeoutMS time.Duration, stopSigCh chan interface{}) ([]byte, error) {
+func (recoverEngine *DataRecoverEngine) getShardFromNetwork(hash common.Hash, loc P2PLocation, timeoutMS time.Duration, stopSigCh chan interface{}) ([]byte, error) {
 	success := make(chan interface{})
 	errCh := make(chan error)
 	go func() {
 		//recieve data
-		shard, err := codec.retrieveData(loc, hash)
+		shard, err := recoverEngine.retrieveData(loc, hash)
 		if err != nil {
 			errCh <- err
 		} else {
@@ -277,8 +278,8 @@ func (codec *DataRecoverEngine) getShardFromNetwork(hash common.Hash, loc P2PLoc
 	}
 }
 
-func (codec *DataRecoverEngine) retrieveData(loc P2PLocation, hash common.Hash) ([]byte, error) {
+func (recoverEngine *DataRecoverEngine) retrieveData(loc P2PLocation, hash common.Hash) ([]byte, error) {
 	// Read p2p network
-	data, _ := codec.p2p.RetrieveData(loc, hash)
+	data, _ := recoverEngine.p2p.RetrieveData(loc, hash)
 	return data, nil
 }

--- a/recovery/recovery.go
+++ b/recovery/recovery.go
@@ -1,0 +1,231 @@
+// Package recovery provides the rs lib to handle data recovery request.
+package recovery
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/klauspost/reedsolomon"
+	"github.com/yottachain/YTFS"
+	ytfsCommon "github.com/yottachain/YTFS/common"
+)
+
+// DataRecoverEngine the rs codec to recovery data
+type DataRecoverEngine struct {
+	recoveryEnc	reedsolomon.Encoder
+	config      *DataCodecOptions
+	ytfs        *ytfs.YTFS
+
+	p2p         P2PNetwork
+
+	taskList	[]TaskDescription
+	taskCh		chan *TaskDescription
+	taskStatus  map[uint64]TaskResponse
+
+	lock        sync.Mutex
+}
+
+// TaskDescription describes the recovery task.
+type TaskDescription struct {
+	// ID of this TaskDescription
+	ID        uint64
+	// [M+N] hashes, and nil indicates those missed
+	Hashes	  []common.Hash
+	// [M+N] locations, as Yotta keeps relative data in different location
+	Locations []P2PLocation
+	// Index of recovery data in shards
+	Index     uint32
+}
+
+// ResponseCode represent a task status.
+type ResponseCode int
+// task status code.
+const (
+	PendingTask ResponseCode = iota
+	ProcessingTask
+	SuccessTask
+	ErrorTask
+)
+
+// TaskResponse descirbes the status of the task 
+type TaskResponse struct {
+	Status ResponseCode
+	Desc   string
+}
+
+// NewDataCodec creates recovery data codec
+func NewDataCodec(ytfs *ytfs.YTFS, p2p P2PNetwork, opt *DataCodecOptions) (*DataRecoverEngine, error) {
+	enc, error := reedsolomon.New(opt.DataShards, opt.ParityShards)
+	if error != nil {
+		return nil, error
+	}
+
+	maxTasks := opt.MaxTaskInParallel
+	if maxTasks <= 0 || maxTasks > 8 {
+		maxTasks = 8
+	}
+
+	codec := &DataRecoverEngine{
+		enc,
+		opt,
+		ytfs,
+		p2p,
+		[]TaskDescription{},
+		make(chan *TaskDescription, maxTasks),
+		map[uint64]TaskResponse{},
+		sync.Mutex{},
+	}
+
+	go codec.startRecieveTask()
+	return codec, nil
+}
+
+func (codec *DataRecoverEngine) startRecieveTask() {
+	running := 0
+	done := make(chan interface{})
+	for ;; {
+		select {
+		case <- codec.taskCh:
+			if running < codec.config.MaxTaskInParallel {
+				running++
+				codec.recordTaskResponse(codec.taskList[0], TaskResponse{PendingTask, ""})
+				go codec.doRecoverData(codec.taskList[0], done)
+				codec.taskList = codec.taskList[1:]
+			}
+		case <- done:
+			running--
+		}
+	}
+}
+
+// RecoverData recieves a recovery task and start working later on
+func (codec *DataRecoverEngine) RecoverData(td TaskDescription) TaskResponse {
+	codec.lock.Lock()
+	defer codec.lock.Unlock()
+	err := codec.validateTask(td)
+	if err != nil {
+		return TaskResponse{ErrorTask, err.Error()}
+	}
+
+	codec.taskList = append(codec.taskList, td)
+	codec.taskCh <- &td
+
+	return codec.taskStatus[td.ID]
+}
+
+func (codec *DataRecoverEngine) validateTask(td TaskDescription) error {
+	// verify hash
+	parityShards := 0
+	for _, hash := range td.Hashes {
+		if hash == (common.Hash{}) {
+			parityShards++
+		}
+	}
+
+	if len(td.Hashes) != codec.config.DataShards+codec.config.ParityShards {
+		return fmt.Errorf("Input hashes length != DataShards+ParityShards")
+	}
+
+	if parityShards > codec.config.ParityShards {
+		return fmt.Errorf("Input parityShards > config.ParityShards")
+	}
+
+	// verify network
+	return nil
+}
+
+func (codec *DataRecoverEngine) doRecoverData(td TaskDescription, done chan interface{}) {
+	shardReady := make(chan interface{})
+	timeoutCh := make(chan common.Hash)
+	shards := make([][]byte, codec.config.DataShards+codec.config.ParityShards)
+	for i:=uint32(0);i<uint32(len(shards));i++{
+		if i == td.Index {
+			shards[i] = nil
+		} else {
+			shards[i] = make([]byte, codec.ytfs.Meta().DataBlockSize)
+		}
+	}
+
+	for i:=0;i<len(td.Hashes);i++{
+		if td.Hashes[i] != (common.Hash{}) {
+			go codec.getShardFromNetwork(td.Hashes[i], td.Locations[i], shards, i, codec.config.TimeoutInMS, shardReady, timeoutCh)
+		}
+	}
+
+	codec.recordTaskResponse(td, TaskResponse{ProcessingTask, "Retrieve data from P2P network"})
+
+	dataReceived := 0
+	for ;; {
+		select{
+		case <-shardReady:
+			dataReceived++
+		case hash := <-timeoutCh:
+			codec.recordError(td, fmt.Errorf("Retrieve %x data timeout", hash))
+			return
+		}
+
+		if dataReceived == codec.config.DataShards {
+			break
+		}
+	}
+
+	codec.recordTaskResponse(td, TaskResponse{ProcessingTask, "EC recovering"})
+	// Reconstruct the shards
+	err := codec.recoveryEnc.Reconstruct(shards)
+	if err != nil {
+		codec.recordError(td, err)
+		return
+	}
+
+	if codec.ytfs != nil {
+		err = codec.ytfs.Put(ytfsCommon.IndexTableKey(td.Hashes[td.Index]), shards[td.Index])
+		if err != nil {
+			codec.recordError(td, err)
+			return	
+		}
+	}
+
+	codec.recordTaskResponse(td, TaskResponse{SuccessTask, ""})
+	done <- struct{}{}
+}
+
+// RecoverStatus queries the status of a task
+func (codec *DataRecoverEngine) RecoverStatus(td TaskDescription) TaskResponse {
+	return codec.taskStatus[td.ID]
+}
+
+func (codec *DataRecoverEngine) recordError(td TaskDescription, err error) {
+	codec.recordTaskResponse(td, TaskResponse{ErrorTask, err.Error()})
+}
+
+func (codec *DataRecoverEngine) recordTaskResponse(td TaskDescription, res TaskResponse) {
+	//TODO: link to levelDB
+	codec.taskStatus[td.ID] = res
+}
+
+func (codec *DataRecoverEngine) getShardFromNetwork(hash common.Hash, loc P2PLocation,
+						shards [][]byte, i int, timeoutMS time.Duration,
+						shardReady chan interface{}, timeoutCh chan common.Hash) {
+	success := make(chan interface{})
+	go func() {
+		//recieve data
+		codec.retrieveData(loc, hash, shards[i])
+		success <- struct{}{}
+	}()
+
+	select {
+	case <- success:
+		shardReady <- struct{}{}
+	case <- time.After(timeoutMS*time.Millisecond):
+		timeoutCh <- hash
+	}
+}
+
+func (codec *DataRecoverEngine) retrieveData(loc P2PLocation, hash common.Hash, data []byte) error {
+	// Read p2p network
+	// time.Sleep(30*time.Millisecond)
+	codec.p2p.RetrieveData(loc, data)
+	return nil
+}

--- a/recovery/recovery_option.go
+++ b/recovery/recovery_option.go
@@ -4,17 +4,17 @@ import (
 	"time"
 )
 
-// DataCodecOptions describes the options of recovery module
-type DataCodecOptions struct {
-	DataShards        int
-	ParityShards      int
-	MaxTaskInParallel int
+// DataRecoverOptions describes the options of recovery module
+type DataRecoverOptions struct {
+	DataShards        uint32
+	ParityShards      uint32
+	MaxTaskInParallel uint32
 	TimeoutInMS       time.Duration
 }
 
-// DefaultRecoveryOption gives the default data recovery codec config
-func DefaultRecoveryOption() *DataCodecOptions {
-	return &DataCodecOptions{
+// DefaultRecoveryOption gives the default data recovery engine config
+func DefaultRecoveryOption() *DataRecoverOptions {
+	return &DataRecoverOptions{
 		3,
 		4,
 		12,

--- a/recovery/recovery_option.go
+++ b/recovery/recovery_option.go
@@ -1,0 +1,23 @@
+package recovery
+
+import (
+	"time"
+)
+
+// DataCodecOptions describes the options of recovery module
+type DataCodecOptions struct{
+	DataShards			int
+	ParityShards        int
+	MaxTaskInParallel	int
+	TimeoutInMS			time.Duration
+}
+
+// DefaultRecoveryOption gives the default data recovery codec config
+func DefaultRecoveryOption() *DataCodecOptions {
+	return &DataCodecOptions{
+		5,
+		3,
+		2,
+		5000,
+	}
+}

--- a/recovery/recovery_option.go
+++ b/recovery/recovery_option.go
@@ -5,11 +5,11 @@ import (
 )
 
 // DataCodecOptions describes the options of recovery module
-type DataCodecOptions struct{
-	DataShards			int
-	ParityShards        int
-	MaxTaskInParallel	int
-	TimeoutInMS			time.Duration
+type DataCodecOptions struct {
+	DataShards        int
+	ParityShards      int
+	MaxTaskInParallel int
+	TimeoutInMS       time.Duration
 }
 
 // DefaultRecoveryOption gives the default data recovery codec config

--- a/recovery/recovery_option.go
+++ b/recovery/recovery_option.go
@@ -15,9 +15,9 @@ type DataCodecOptions struct{
 // DefaultRecoveryOption gives the default data recovery codec config
 func DefaultRecoveryOption() *DataCodecOptions {
 	return &DataCodecOptions{
-		5,
 		3,
-		2,
+		4,
+		12,
 		5000,
 	}
 }

--- a/recovery/recovery_p2p.go
+++ b/recovery/recovery_p2p.go
@@ -36,6 +36,15 @@ func (mock P2PMock) RetrieveData(peer P2PLocation, hash common.Hash) ([]byte, er
 	return msgByte, nil
 }
 
+// NodeList reports all node addresses in this p2p network
+func (mock P2PMock) NodeList() []P2PLocation {
+	nodes := []P2PLocation{}
+	for key := range mock.networkData {
+		nodes = append(nodes, key)
+	}
+	return nodes
+}
+
 // InititalP2PMock initializes P2P mock module
 func InititalP2PMock(peers []P2PLocation, dataBlks [][]byte, networkParams ...time.Duration) (P2PNetwork, error) {
 	p2p := P2PMock{

--- a/recovery/recovery_p2p.go
+++ b/recovery/recovery_p2p.go
@@ -1,6 +1,6 @@
 package recovery
 
-import(
+import (
 	// "fmt"
 	// "bytes"
 	"time"
@@ -17,13 +17,13 @@ type P2PNetwork interface {
 }
 
 // P2PMock mocks a p2p network for test
-type P2PMock struct{
+type P2PMock struct {
 	network map[P2PLocation][]byte
 }
 
 // RetrieveData get data from p2p network address
 func (mock P2PMock) RetrieveData(peer P2PLocation, msgByte []byte) error {
-	time.Sleep(50*time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	copy(msgByte, mock.network[peer])
 	return nil
 }
@@ -34,10 +34,8 @@ func InititalP2PMock(peers []P2PLocation, dataBlks [][]byte) (P2PNetwork, error)
 		map[P2PLocation][]byte{},
 	}
 
-	for i:=0;i<len(peers);i++{
-		p2p.network[peers[i]]=dataBlks[i]
+	for i := 0; i < len(peers); i++ {
+		p2p.network[peers[i]] = dataBlks[i]
 	}
 	return p2p, nil
 }
-
-

--- a/recovery/recovery_p2p.go
+++ b/recovery/recovery_p2p.go
@@ -3,6 +3,7 @@ package recovery
 import(
 	// "fmt"
 	// "bytes"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -22,6 +23,7 @@ type P2PMock struct{
 
 // RetrieveData get data from p2p network address
 func (mock P2PMock) RetrieveData(peer P2PLocation, msgByte []byte) error {
+	time.Sleep(50*time.Millisecond)
 	copy(msgByte, mock.network[peer])
 	return nil
 }

--- a/recovery/recovery_p2p.go
+++ b/recovery/recovery_p2p.go
@@ -1,0 +1,41 @@
+package recovery
+
+import(
+	// "fmt"
+	// "bytes"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// P2PLocation is the address of the p2p network
+type P2PLocation common.Address
+
+// P2PNetwork interface defines the P2P operations and implements mock for test
+type P2PNetwork interface {
+	RetrieveData(peer P2PLocation, msgByte []byte) error
+}
+
+// P2PMock mocks a p2p network for test
+type P2PMock struct{
+	network map[P2PLocation][]byte
+}
+
+// RetrieveData get data from p2p network address
+func (mock P2PMock) RetrieveData(peer P2PLocation, msgByte []byte) error {
+	copy(msgByte, mock.network[peer])
+	return nil
+}
+
+// InititalP2PMock initializes P2P mock module
+func InititalP2PMock(peers []P2PLocation, dataBlks [][]byte) (P2PNetwork, error) {
+	p2p := P2PMock{
+		map[P2PLocation][]byte{},
+	}
+
+	for i:=0;i<len(peers);i++{
+		p2p.network[peers[i]]=dataBlks[i]
+	}
+	return p2p, nil
+}
+
+

--- a/recovery/recovery_p2p.go
+++ b/recovery/recovery_p2p.go
@@ -13,29 +13,43 @@ type P2PLocation common.Address
 
 // P2PNetwork interface defines the P2P operations and implements mock for test
 type P2PNetwork interface {
-	RetrieveData(peer P2PLocation, msgByte []byte) error
+	RetrieveData(peer P2PLocation, hash common.Hash) ([]byte, error)
 }
 
 // P2PMock mocks a p2p network for test
 type P2PMock struct {
-	network map[P2PLocation][]byte
+	networkData  map[P2PLocation][]byte
+	networkDelay map[P2PLocation]time.Duration
 }
 
+const defaultNetworkDelayInMS time.Duration = 50
+
 // RetrieveData get data from p2p network address
-func (mock P2PMock) RetrieveData(peer P2PLocation, msgByte []byte) error {
-	time.Sleep(50 * time.Millisecond)
-	copy(msgByte, mock.network[peer])
-	return nil
+func (mock P2PMock) RetrieveData(peer P2PLocation, hash common.Hash) ([]byte, error) {
+	if delay, ok := mock.networkDelay[peer]; ok {
+		time.Sleep(delay * time.Millisecond)
+	} else {
+		time.Sleep(defaultNetworkDelayInMS * time.Millisecond)
+	}
+	msgByte := make([]byte, len(mock.networkData[peer]))
+	copy(msgByte, mock.networkData[peer])
+	return msgByte, nil
 }
 
 // InititalP2PMock initializes P2P mock module
-func InititalP2PMock(peers []P2PLocation, dataBlks [][]byte) (P2PNetwork, error) {
+func InititalP2PMock(peers []P2PLocation, dataBlks [][]byte, networkParams ...time.Duration) (P2PNetwork, error) {
 	p2p := P2PMock{
 		map[P2PLocation][]byte{},
+		map[P2PLocation]time.Duration{},
 	}
 
 	for i := 0; i < len(peers); i++ {
-		p2p.network[peers[i]] = dataBlks[i]
+		p2p.networkData[peers[i]] = dataBlks[i]
 	}
+
+	for i, delay := range networkParams {
+		p2p.networkDelay[peers[i]] = delay
+	}
+
 	return p2p, nil
 }

--- a/recovery/recovery_test.go
+++ b/recovery/recovery_test.go
@@ -1,0 +1,112 @@
+// Package recovery
+package recovery
+
+import (
+	"bytes"
+	"io/ioutil"
+	"crypto/sha256"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/klauspost/reedsolomon"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/yottachain/YTFS"
+	ytfsOpt "github.com/yottachain/YTFS/opt"
+	ytfsCommon "github.com/yottachain/YTFS/common"
+)
+
+func TestNewDataRecovery(t *testing.T) {
+	_, err := NewDataCodec(nil, nil, DefaultRecoveryOption())
+	if err != nil {
+		t.Fail()
+	}
+}
+
+func randomFill(size uint32) []byte {
+	buf := make([]byte, size, size)
+	rand.Read(buf)
+	return buf
+}
+
+func createShards(dataShards, parityShards int) ([]common.Hash, [][]byte) {
+	shards := make([][]byte, dataShards + parityShards)
+	hashes := make([]common.Hash, dataShards + parityShards)
+	dataBlkSize := ytfsOpt.DefaultOptions().DataBlockSize
+	for i:=0;i<dataShards;i++{
+		shards[i] = randomFill(dataBlkSize)
+		sum256 := sha256.Sum256(shards[i])
+		hashes[i] = common.BytesToHash(sum256[:])
+	}
+
+	for i:=dataShards;i<dataShards+parityShards;i++{
+		shards[i] = make([]byte, dataBlkSize)
+	}
+
+	return hashes,shards
+}
+
+func createAndDistributeData(dataShards, parityShards int) (P2PNetwork, []P2PLocation, []common.Hash, [][]byte) {
+	hashes, shards := createShards(dataShards, parityShards)
+	locations := make([]P2PLocation, len(hashes))
+	enc, _ := reedsolomon.New(dataShards, parityShards)
+	enc.Encode(shards)
+	//update parity hash
+	for i:=dataShards;i<dataShards+parityShards;i++{
+		sum256 := sha256.Sum256(shards[i])
+		hashes[i] = common.BytesToHash(sum256[:])
+	}
+
+	for i:=0;i<dataShards+parityShards;i++{
+		locations[i] = P2PLocation(common.BytesToAddress(hashes[i][:]))
+	}
+
+	p2p, _ := InititalP2PMock(locations, shards)
+	return p2p, locations, hashes, shards
+}
+
+func TestDataRecovery(t *testing.T) {
+	rootDir, err := ioutil.TempDir("/tmp", "ytfsTest")
+	config := ytfsOpt.DefaultOptions()
+	// defer os.Remove(config.StorageName)
+
+	yd, err := ytfs.Open(rootDir, config)
+
+	recConfig := DefaultRecoveryOption()
+	p2p, locs, hashes, shards := createAndDistributeData(recConfig.DataShards, recConfig.ParityShards)
+
+	codec, err := NewDataCodec(yd, p2p, recConfig)
+	if err != nil {
+		t.Fail()
+	}
+
+	tdList := []TaskDescription{}
+	for i:=0;i<1;i++{
+// for i:=0;i<len(shards);i++{
+		recoverHashes := append([]common.Hash{}, hashes[:i]...)
+		recoverHashes = append(recoverHashes, common.Hash{})
+		recoverHashes = append(recoverHashes, hashes[i+1:]...)
+		td := TaskDescription{
+			uint64(i),
+			recoverHashes,
+			locs,
+			uint32(i),
+		}
+		codec.RecoverData(td)
+		tdList = append(tdList, td)
+	}
+
+	time.Sleep(10*time.Second)
+	for _,td := range tdList{
+		tdStatus := codec.RecoverStatus(td)
+		if tdStatus.Status != SuccessTask {
+			t.Fatalf("ERROR: td status(%d): %s", tdStatus.Status, tdStatus.Desc)
+		} else {
+			data, err := yd.Get(ytfsCommon.IndexTableKey(td.Hashes[td.Index]))
+			if err != nil || bytes.Compare(data, shards[td.Index]) != 0 {
+				t.Fatalf("Error: err(%v), dataCompare (%d). data(%v) shards(%v)",
+				err, bytes.Compare(data, shards[td.Index]), data[:16], shards[td.Index][:16])
+			}
+		}
+	}
+}

--- a/recovery/recovery_test.go
+++ b/recovery/recovery_test.go
@@ -79,7 +79,7 @@ func TestDataRecovery(t *testing.T) {
 	p2p, locs, hashes, shards := createP2PAndDistributeData(recConfig.DataShards, recConfig.ParityShards)
 
 	for i:=0;i<len(shards);i++{
-		fmt.Printf("shard[%d] = %v\n", i, shards[i][:20])
+		fmt.Printf("Data[%d] = %x:%x\n", i, hashes[i], shards[i][:20])
 	}
 
 	codec, err := NewDataCodec(yd, p2p, recConfig)

--- a/recovery/recovery_test.go
+++ b/recovery/recovery_test.go
@@ -215,3 +215,18 @@ func TestDataRecoveryError(t *testing.T) {
 		t.Log("Expected error:", tdStatus)
 	}
 }
+
+func BenchmarkDataRecovery(b *testing.B) {
+	dataShards, parityShards := 2, 3
+	_, _, _, shards := createP2PAndDistributeData(dataShards, parityShards)
+	rsEnc, err := reedsolomon.New(dataShards, parityShards)
+	if err != nil {
+		b.Fatal(err)
+	}
+	missID := rand.Int() % len(shards)
+	shards[missID] = nil
+
+	for n := 0; n < b.N; n++ {
+		rsEnc.Reconstruct(shards)
+	}
+}

--- a/recovery/recovery_test.go
+++ b/recovery/recovery_test.go
@@ -87,10 +87,10 @@ func TestDataRecovery(t *testing.T) {
 		t.Fail()
 	}
 
-	tdList := []TaskDescription{}
+	tdList := []*TaskDescription{}
 	// for i:=0;i<1;i++{
 	for i:=0;i<len(shards);i++{
-		td := TaskDescription{
+		td := &TaskDescription{
 			uint64(i),
 			hashes,
 			locs,
@@ -100,10 +100,9 @@ func TestDataRecovery(t *testing.T) {
 		tdList = append(tdList, td)
 	}
 
-	time.Sleep(5*time.Second)
+	time.Sleep(2*time.Second)
 	for _,td := range tdList{
 		tdStatus := codec.RecoverStatus(td)
-		fmt.Println(td.ID, tdStatus)
 		if tdStatus.Status != SuccessTask {
 			t.Fatalf("ERROR: td status(%d): %s", tdStatus.Status, tdStatus.Desc)
 		} else {

--- a/recovery/recovery_test.go
+++ b/recovery/recovery_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestNewDataRecovery(t *testing.T) {
-	_, err := NewDataRecoverEngine(nil, nil, DefaultRecoveryOption())
+	_, err := NewEngine(nil, nil, DefaultRecoveryOption())
 	if err != nil {
 		t.Fail()
 	}
@@ -88,7 +88,7 @@ func TestDataRecovery(t *testing.T) {
 		fmt.Printf("Data[%d] = %x:%x\n", i, hashes[i], shards[i][:20])
 	}
 
-	dataRecoverEngine, err := NewDataRecoverEngine(yd, p2pNet, recConfig)
+	dataRecoverEngine, err := NewEngine(yd, p2pNet, recConfig)
 	if err != nil {
 		t.Fail()
 	}
@@ -137,7 +137,7 @@ func TestMultiplyDataRecovery(t *testing.T) {
 		fmt.Printf("Data[%d] = %x:%x\n", i, hashes[i], shards[i][:20])
 	}
 
-	dataRecoverEngine, err := NewDataRecoverEngine(yd, p2pNet, recConfig)
+	dataRecoverEngine, err := NewEngine(yd, p2pNet, recConfig)
 	if err != nil {
 		t.Fail()
 	}
@@ -183,7 +183,7 @@ func TestDataRecoveryError(t *testing.T) {
 		fmt.Printf("Data[%d] = %x:%x\n", i, hashes[i], shards[i][:20])
 	}
 
-	dataRecoverEngine, err := NewDataRecoverEngine(yd, p2pNet, recConfig)
+	dataRecoverEngine, err := NewEngine(yd, p2pNet, recConfig)
 	if err != nil {
 		t.Fail()
 	}
@@ -228,7 +228,7 @@ func setupBenchmarkEnv(recConfig *DataRecoverOptions, p2pDelays ...time.Duration
 	hashes, shards := createData(recConfig.DataShards, recConfig.ParityShards)
 	p2pNet, p2pNodes := initailP2PMockWithShards(hashes, shards, p2pDelays...)
 
-	dataRecoverEngine, _ := NewDataRecoverEngine(nil, p2pNet, recConfig)
+	dataRecoverEngine, _ := NewEngine(nil, p2pNet, recConfig)
 	return dataRecoverEngine, hashes, p2pNodes
 }
 

--- a/sampling/sampling.go
+++ b/sampling/sampling.go
@@ -1,0 +1,177 @@
+// Package sampling holds logic of sampling test of YTFS
+package sampling
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"sync"
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/yottachain/YTFS/recovery"
+	"github.com/yottachain/YTFS/opt"
+
+)
+
+// ResponseCode represent a task status.
+type ResponseCode int
+
+// task status code.
+const (
+	SuccessTask ResponseCode = iota
+	ProcessingTask
+	PendingTask
+	ErrorTask
+	UnknownTask
+)
+
+func (response ResponseCode) String() string {
+	switch response {
+	case SuccessTask:
+		return "SuccessTask"
+	case ProcessingTask:
+		return "ProcessingTask"
+	case PendingTask:
+		return "PendingTask"
+	case ErrorTask:
+		return "ErrorTask"
+	case UnknownTask:
+		fallthrough
+	default:
+		return "UnkownStatus"
+	}
+}
+
+// TaskDescription is the description of sampling task
+type TaskDescription struct {
+	ID      uint64
+	Hash    common.Hash
+	Address recovery.P2PLocation
+}
+
+// TaskRespond is the response of the task
+type TaskRespond struct {
+	TaskID uint64
+	Status ResponseCode
+	Desc   string
+}
+
+// DataSampleEngine is the sampling task list manager
+type DataSampleEngine struct {
+	config     *Config
+	p2p        recovery.P2PNetwork
+	taskList   []*TaskDescription
+	taskCh     chan *TaskDescription
+	taskStatus map[uint64]TaskRespond
+	lock       sync.Mutex
+}
+
+// NewEngine creates a new sampling engine
+func NewEngine(p2p recovery.P2PNetwork, config *Config) (*DataSampleEngine, error) {
+	engine := &DataSampleEngine{
+		config,
+		p2p,
+		[]*TaskDescription{},
+		make(chan *TaskDescription),
+		map[uint64]TaskRespond{},
+		sync.Mutex{},
+	}
+
+	go engine.startTaskHandling()
+	return engine, nil
+}
+
+// RequestSampling is the interface of others to give in a sampling task
+func (engine *DataSampleEngine) RequestSampling(task *TaskDescription) error {
+	if !engine.validateTask(task) {
+		return fmt.Errorf("ERROR: incorrect sample request %v", task)
+	}
+	// sequenced op on chan
+	engine.taskCh <- task
+	engine.recordTaskResponse(task, PendingTask, "Task pending")
+	return nil
+}
+
+// ReportTaskStatus reports task status
+func (engine *DataSampleEngine) ReportTaskStatus(task *TaskDescription) TaskRespond {
+	engine.lock.Lock()
+	defer engine.lock.Unlock()
+	if res, ok := engine.taskStatus[task.ID]; ok {
+		return res
+	}
+
+	return TaskRespond{task.ID, UnknownTask, UnknownTask.String()}
+}
+
+func (engine *DataSampleEngine) validateTask(task *TaskDescription) bool {
+	return true
+} 
+
+func (engine *DataSampleEngine) startTaskHandling() {
+	done := make(chan interface{})
+	for {
+		select {
+		case td := <-engine.taskCh:
+			engine.taskList = append(engine.taskList, td)
+		case <-time.After(time.Duration(engine.config.FrequenceInSecond)*time.Second):
+			if opt.DebugPrint {
+				fmt.Println("Time to sample")
+			}
+			running := uint32(0)
+			for len(engine.taskList) != 0 && running < engine.config.MaxSamplingThread {
+				running++
+				task := engine.taskList[0]
+				engine.taskList = engine.taskList[1:]
+				go engine.doSampling(task, done)
+			}
+		}
+	}
+}
+
+func (engine *DataSampleEngine) doSampling(td *TaskDescription, done chan interface{}) {
+	dataCh := make(chan []byte)
+	errCh := make(chan error)
+	go func() {
+		sample, err := engine.p2p.RetrieveData(td.Address, td.Hash)
+		if err != nil {
+			errCh <- err
+		} else {
+			dataCh <- sample
+		}
+	}()
+
+	select {
+	case sample := <- dataCh:
+		err := engine.checkDataConsistence(td.Hash, sample)
+		if err != nil {
+			engine.recordTaskResponse(td, ErrorTask, err.Error())
+		} else {
+			engine.recordTaskResponse(td, SuccessTask, "Sample check passed")
+		}
+	case err := <- errCh:
+		engine.recordTaskResponse(td, ErrorTask, err.Error())
+	case <- time.After(time.Duration(engine.config.P2PTimeoutInMS)*time.Millisecond):
+		engine.recordTaskResponse(td, ErrorTask, "P2P transfer timeout")
+	}
+}
+
+func (engine *DataSampleEngine) checkDataConsistence(hash common.Hash, data []byte) error {
+	sum256 := sha256.Sum256(data)
+	dataHash := common.BytesToHash(sum256[:])
+	if bytes.Compare(dataHash[:], hash[:]) == 0 {
+		return nil
+	}
+	return fmt.Errorf("Data hash mismatch %x vs %x of data %x", dataHash, hash, data[:20])
+}
+
+func (engine *DataSampleEngine) recordTaskResponse(task *TaskDescription, res ResponseCode, desc string) {
+	engine.lock.Lock()
+	defer engine.lock.Unlock()
+
+	engine.taskStatus[task.ID] = TaskRespond{
+		task.ID,
+		res,
+		desc,
+	}
+}

--- a/sampling/sampling.go
+++ b/sampling/sampling.go
@@ -175,3 +175,8 @@ func (engine *DataSampleEngine) recordTaskResponse(task *TaskDescription, res Re
 		desc,
 	}
 }
+
+func (engine *DataSampleEngine) String() string {
+	return fmt.Sprintf("\nDataSampleEngine Info:\n" + engine.config.String() +
+					   "\nqueue: %d\n", len(engine.taskList))
+}

--- a/sampling/sampling_option.go
+++ b/sampling/sampling_option.go
@@ -1,0 +1,17 @@
+package sampling
+
+// Config is the config of sampling engine
+type Config struct {
+	FrequenceInSecond uint32
+	MaxSamplingThread uint32
+	P2PTimeoutInMS    uint32
+}
+
+// DefaultOption is the default option of data sample engine
+func DefaultOption() *Config {
+	return &Config{
+		1,
+		1,
+		500,
+	}
+}

--- a/sampling/sampling_option.go
+++ b/sampling/sampling_option.go
@@ -1,10 +1,19 @@
 package sampling
 
+import (
+	"fmt"
+)
+
 // Config is the config of sampling engine
 type Config struct {
 	FrequenceInSecond uint32
 	MaxSamplingThread uint32
 	P2PTimeoutInMS    uint32
+}
+
+func (config Config) String() string {
+	return fmt.Sprintf("\nFrequenceInSecond: %d second\nMaxSamplingThread: %d\nP2PTimeoutInMS: %d ms\n",
+				config.FrequenceInSecond, config.MaxSamplingThread, config.P2PTimeoutInMS)
 }
 
 // DefaultOption is the default option of data sample engine

--- a/sampling/sampling_test.go
+++ b/sampling/sampling_test.go
@@ -195,3 +195,28 @@ func TestStatusError(t *testing.T) {
 		}
 	}
 }
+
+func TestTaskFanIn(t *testing.T) {
+	opt.DebugPrint = true
+	config := DefaultOption()
+	config.FrequenceInSecond = 300
+	n := 10000
+	hashes, data := createData(1)
+	p2pNet, p2pNodes := initailP2PMockWithShards(hashes, data, 500)
+
+	se, err := NewEngine(p2pNet, config)
+	if err != nil {
+		t.Fail()
+	}
+
+	for i:=0;i<n;i++{
+		task := &TaskDescription{
+			uint64(i),
+			hashes[0],
+			p2pNodes[0],
+		}
+		se.RequestSampling(task)
+	}
+
+	t.Log(se)
+}

--- a/sampling/sampling_test.go
+++ b/sampling/sampling_test.go
@@ -1,0 +1,197 @@
+package sampling
+
+import (
+	"crypto/sha256"
+	"math/rand"
+	"time"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/yottachain/YTFS/opt"
+	"github.com/yottachain/YTFS/recovery"
+)
+
+func TestNewEngine(t *testing.T) {
+	opt.DebugPrint = true
+	config := DefaultOption()
+	_, err := NewEngine(nil, config)
+	if err != nil {
+		t.Fail()
+	}
+	time.Sleep(3*time.Second)
+}
+
+func randomFill(size uint32) []byte {
+	buf := make([]byte, size, size)
+	head := make([]byte, 16, 16)
+	rand.Seed(int64(time.Now().Nanosecond()))
+	rand.Read(head)
+	copy(buf, head)
+	return buf
+}
+
+func createData(n int) ([]common.Hash, [][]byte) {
+	data := make([][]byte, n)
+	hashes := make([]common.Hash, n)
+	for i := 0; i < n; i++ {
+		data[i] = randomFill(32768)
+		sum256 := sha256.Sum256(data[i])
+		hashes[i] = common.BytesToHash(sum256[:])
+	}
+
+	return hashes, data
+}
+
+func initailP2PMockWithShards(hashes []common.Hash, data [][]byte, delays ...time.Duration) (recovery.P2PNetwork, []recovery.P2PLocation) {
+	locations := make([]recovery.P2PLocation, len(hashes))
+	for i := 0; i < len(hashes); i++ {
+		locations[i] = recovery.P2PLocation(common.BytesToAddress(hashes[i][:]))
+	}
+
+	p2p, _ := recovery.InititalP2PMock(locations, data, delays...)
+	return p2p, locations
+}
+
+func TestSampleP2P(t *testing.T) {
+	opt.DebugPrint = true
+	config := DefaultOption()
+
+	n := 2
+	hashes, data := createData(n)
+	p2pNet, p2pNodes := initailP2PMockWithShards(hashes, data)
+
+	se, err := NewEngine(p2pNet, config)
+	if err != nil {
+		t.Fail()
+	}
+
+	for i:=0;i<n;i++{
+		task := &TaskDescription{
+			uint64(i),
+			hashes[i],
+			p2pNodes[i],
+		}
+		se.RequestSampling(task)
+	}
+
+	time.Sleep(3*time.Second)
+	for i:=0;i<n;i++{
+		task := &TaskDescription{
+			uint64(i),
+			hashes[i],
+			p2pNodes[i],
+		}
+		if se.ReportTaskStatus(task).Status != SuccessTask {
+			t.Fatal(i, "test failed:", se.ReportTaskStatus(task).Desc)
+		}
+	}
+}
+
+func TestParallelP2P(t *testing.T) {
+	opt.DebugPrint = true
+	config := DefaultOption()
+	config.MaxSamplingThread = 7
+	n := 20
+	hashes, data := createData(n)
+	p2pNet, p2pNodes := initailP2PMockWithShards(hashes, data)
+
+	se, err := NewEngine(p2pNet, config)
+	if err != nil {
+		t.Fail()
+	}
+
+	for i:=0;i<n;i++{
+		task := &TaskDescription{
+			uint64(i),
+			hashes[i],
+			p2pNodes[i],
+		}
+		se.RequestSampling(task)
+	}
+
+	time.Sleep(4*time.Second)
+	for i:=0;i<n;i++{
+		task := &TaskDescription{
+			uint64(i),
+			hashes[i],
+			p2pNodes[i],
+		}
+		if se.ReportTaskStatus(task).Status != SuccessTask {
+			t.Fatal(i, "test failed:", se.ReportTaskStatus(task).Desc)
+		}
+	}
+}
+
+func TestSampleTaskInQueue(t *testing.T) {
+	opt.DebugPrint = true
+	config := DefaultOption()
+	config.MaxSamplingThread = 1
+	config.FrequenceInSecond = 10
+	n := 20
+	hashes, data := createData(n)
+	p2pNet, p2pNodes := initailP2PMockWithShards(hashes, data)
+
+	se, err := NewEngine(p2pNet, config)
+	if err != nil {
+		t.Fail()
+	}
+
+	for i:=0;i<n;i++{
+		task := &TaskDescription{
+			uint64(i),
+			hashes[i],
+			p2pNodes[i],
+		}
+		se.RequestSampling(task)
+	}
+
+	time.Sleep(4*time.Second)
+	for i:=0;i<n;i++{
+		task := &TaskDescription{
+			uint64(i),
+			hashes[i],
+			p2pNodes[i],
+		}
+		if se.ReportTaskStatus(task).Status != PendingTask {
+			t.Fatal(i, "test failed:", se.ReportTaskStatus(task).Desc)
+		}
+	}
+}
+
+func TestStatusError(t *testing.T) {
+	opt.DebugPrint = true
+	config := DefaultOption()
+	config.P2PTimeoutInMS = 300
+	n := 1
+	hashes, data := createData(n)
+	p2pNet, p2pNodes := initailP2PMockWithShards(hashes, data, 500)
+
+	se, err := NewEngine(p2pNet, config)
+	if err != nil {
+		t.Fail()
+	}
+
+	for i:=0;i<n;i++{
+		task := &TaskDescription{
+			uint64(i),
+			hashes[i],
+			p2pNodes[i],
+		}
+		se.RequestSampling(task)
+	}
+
+	time.Sleep(2*time.Second)
+	for i:=0;i<n;i++{
+		task := &TaskDescription{
+			uint64(i),
+			hashes[i],
+			p2pNodes[i],
+		}
+		if se.ReportTaskStatus(task).Status != ErrorTask {
+			t.Fatal(i, "test failed:", se.ReportTaskStatus(task).Desc)
+		} else {
+			t.Log("Expected:", se.ReportTaskStatus(task))
+		}
+	}
+}

--- a/storage/indexfile.go
+++ b/storage/indexfile.go
@@ -98,7 +98,7 @@ func (indexFile *YTFSIndexFile) Get(key ydcommon.IndexTableKey) (ydcommon.IndexT
 
 	if value, ok := table[key]; ok {
 		if debugPrint {
-			fmt.Println("IndexDB get", key, value)
+			fmt.Printf("IndexDB get %x:%x\n", key, value)
 		}
 		return value, nil
 	}
@@ -113,14 +113,14 @@ func (indexFile *YTFSIndexFile) Get(key ydcommon.IndexTableKey) (ydcommon.IndexT
 
 		if value, ok := table[key]; ok {
 			if debugPrint {
-				fmt.Println("IndexDB get @overflow table", key, value)
+				fmt.Printf("IndexDB get %x:%x @overflow table\n", key, value)
 			}
 			return value, nil
 		}
 	}
 
 	if debugPrint {
-		fmt.Println("IndexDB get", key, "failed, from table", table)
+		fmt.Printf("IndexDB get %x failed, from %d-size table\n", key, len(table))
 	}
 	return 0, errors.ErrDataNotFound
 }
@@ -136,7 +136,7 @@ func (indexFile *YTFSIndexFile) loadTableFromStorage(tbIndex uint32) (map[ydcomm
 	reader.Read(sizeBuf)
 	tableSize := binary.LittleEndian.Uint32(sizeBuf)
 	if debugPrint {
-		fmt.Println("read table size :=", sizeBuf, "from", int64(indexFile.meta.HashOffset)+int64(tbIndex)*int64(tableAllocationSize))
+		fmt.Println("read table size :=", tableSize, "from", int64(indexFile.meta.HashOffset)+int64(tbIndex)*int64(tableAllocationSize))
 	}
 
 	// read table contents
@@ -239,7 +239,7 @@ func (indexFile *YTFSIndexFile) Put(key ydcommon.IndexTableKey, value ydcommon.I
 	}
 
 	if debugPrint {
-		fmt.Println("IndexDB put", key, value)
+		fmt.Printf("IndexDB put %x:%x\n", key, value)
 	}
 
 	if (indexFile.stat.putCount & (indexFile.config.SyncPeriod - 1)) == 0 {


### PR DESCRIPTION
1. Add data reconstruct engine which reconstructs the missed data in YTFS data node.
2. Add data sample engine which implements data sample task queue.
3. Add corresponding test cases.
4. Since P2P is not ready, this time it mocks a P2P network to test code logic and should be link to real p2p network in near future.